### PR TITLE
Minor spelling issue

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -18,7 +18,7 @@ server_scripts {
 
 server_exports { 
 	"GetDiscordRoles",
-	"GetRoleIdfromRoleName",
+	"GetRoleIdFromRoleName",
 	"GetDiscordAvatar",
 	"GetDiscordName",
 	"GetDiscordEmail",


### PR DESCRIPTION
The "F" in "from" wasn't capitalized while Badger Docs showed that it was. This caused issues with a couple of people not knowing why that specific export wasn't working.