### PR TITLE
add caching

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,8 @@ Config = {
 	Guild_ID = '',
 	Bot_Token = '',
 	RoleList = {},
+	CacheDiscordRoles = true, -- true to cache player roles, false to make a new Discord Request every time
+	CacheDiscordRolesTime = 60, -- if CacheDiscordRoles is true, how long to cache roles before clearing (in seconds)
 }
 
 Config.Splash = {

--- a/server.lua
+++ b/server.lua
@@ -403,8 +403,8 @@ function GetDiscordRoles(user)
 			local found = true
 			if Config.CacheDiscordRoles then
 				recent_role_cache[discordId] = roles
+				Citizen.SetTimeout(((Config.CacheDiscordRolesTime or 60)*1000), function() recent_role_cache[discordId] = nil end)
 			end
-			Citizen.SetTimeout(((Config.CacheDiscordRolesTime or 60)*1000), function() recent_role_cache[discordId] = nil end)
 			return roles
 		else
 			print("[Badger_Perms] ERROR: Code 200 was not reached... Returning false. [Member Data NOT FOUND] Error Code: " .. member.code)

--- a/server.lua
+++ b/server.lua
@@ -392,7 +392,7 @@ function GetDiscordRoles(user)
 	end
 
 	if discordId then
-		if recent_role_cache[discordId] then
+		if Config.CacheDiscordRoles and recent_role_cache[discordId] then
 			return recent_role_cache[discordId]
 		end
 		local endpoint = ("guilds/%s/members/%s"):format(Config.Guild_ID, discordId)
@@ -401,8 +401,10 @@ function GetDiscordRoles(user)
 			local data = json.decode(member.data)
 			local roles = data.roles
 			local found = true
-			recent_role_cache[discordId] = roles
-			Citizen.SetTimeout(60000, function() recent_role_cache[discordId] = nil end)
+			if Config.CacheDiscordRoles then
+				recent_role_cache[discordId] = roles
+			end
+			Citizen.SetTimeout(((Config.CacheDiscordRolesTime or 60)*1000), function() recent_role_cache[discordId] = nil end)
 			return roles
 		else
 			print("[Badger_Perms] ERROR: Code 200 was not reached... Returning false. [Member Data NOT FOUND] Error Code: " .. member.code)

--- a/server.lua
+++ b/server.lua
@@ -380,6 +380,8 @@ function GetGuildRoleList()
 	return Caches.RoleList;
 end
 
+local recent_role_cache = {}
+
 function GetDiscordRoles(user)
 	local discordId = nil
 	for _, id in ipairs(GetPlayerIdentifiers(user)) do
@@ -390,12 +392,17 @@ function GetDiscordRoles(user)
 	end
 
 	if discordId then
+		if recent_role_cache[discordId] then
+			return recent_role_cache[discordId]
+		end
 		local endpoint = ("guilds/%s/members/%s"):format(Config.Guild_ID, discordId)
 		local member = DiscordRequest("GET", endpoint, {})
 		if member.code == 200 then
 			local data = json.decode(member.data)
 			local roles = data.roles
 			local found = true
+			recent_role_cache[discordId] = roles
+			Citizen.SetTimeout(60000, function() recent_role_cache[discordId] = nil end)
 			return roles
 		else
 			print("[Badger_Perms] ERROR: Code 200 was not reached... Returning false. [Member Data NOT FOUND] Error Code: " .. member.code)


### PR DESCRIPTION
This will reduce requests to the discord API endpoint for larger servers, which tends to be a bottleneck that results in missing perms