### PR TITLE
add support for multiple guilds

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,9 @@
 Config = {
-	Guild_ID = '',
+	Guild_ID = '', -- Set to the ID of your guild (or your Primary guild if using Multiguild)
+  Multiguild = false, -- Set to true if you want to use multiple guilds
+  Guilds = {
+    ["name"] = "guild_id", -- Replace this with a name, like "main"
+  },
 	Bot_Token = '',
 	RoleList = {},
 	CacheDiscordRoles = true, -- true to cache player roles, false to make a new Discord Request every time


### PR DESCRIPTION
- Optional
- Should not change any functionality for resources using current version
- Allows specifying guilds in a similar way to the ['name'] = "ID" format for the RoleList, and pulling data from them using specified arguments in the main functions.