### PR TITLE
nil ~= nil

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -134,8 +134,7 @@ end
 function CheckEqual(role1, role2, guild --[[optional]])
     local roleID1 = FetchRoleID(role1, guild)
     local roleID2 = FetchRoleID(role2, guild)
-
-    if roleID1 == roleID2 then 
+    if roleID1 == roleID2 and type(roleID1) ~= "nil" then 
 	return true
     end
 


### PR DESCRIPTION
this change is implemented to enforce nil ~= nil, in the same way that SQL enforces NULL is not equal to NULL, as it's considered unknown.
This prevents a pair erroneous role names/IDs from generating a false positive in cases where things like roles/perms depend upon a response of True from the CheckEqual function.