### PR TITLE
X-Audit-Log-Reason header, Voice channel switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ RegisterCommand('testResource', function(source, args, rawCommand)
 -- Usage:
 	SetNickname(user, "🦡Badger")
 	SetNickname(user, "")
+
+-- function ChangeDiscordVoice(user, voiceID)
+-- Returns error code 400 if voice channel ID is incorrect
+-- Usage:
+	ChangeDiscordVoice(user, 123456789123456789)
 end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,13 +161,14 @@ RegisterCommand('testResource', function(source, args, rawCommand)
 -- function SetNickname(user, nickname)
 -- Returns error code 403 if the user is higher than the bot
 -- Usage:
-	SetNickname(user, "🦡Badger")
-	SetNickname(user, "")
+	SetNickname(user, "🦡Badger", "Set nickname")
+	SetNickname(user, "", "Reset nickname")
 
 -- function ChangeDiscordVoice(user, voiceID)
 -- Returns error code 400 if voice channel ID is incorrect
 -- Usage:
 	ChangeDiscordVoice(user, 123456789123456789)
+	ChangeDiscordVoice(user, 123456789123456789, "Moved "..GetPlayerName(user).." to the admin channel")
 end)
 ```
 

--- a/example.lua
+++ b/example.lua
@@ -127,4 +127,9 @@ RegisterCommand('testResource', function(source, args, rawCommand)
 -- Usage:
 	SetNickname(user, "🦡Badger")
 	SetNickname(user, "")
+
+-- function ChangeDiscordVoice(user, voiceID)
+-- Returns error code 400 if voice channel ID is incorrect
+-- Usage:
+	ChangeDiscordVoice(user, 123456789123456789)
 end)

--- a/example.lua
+++ b/example.lua
@@ -125,11 +125,12 @@ RegisterCommand('testResource', function(source, args, rawCommand)
 -- function SetNickname(user, nickname)
 -- Returns error code 403 if the user is higher than the bot
 -- Usage:
-	SetNickname(user, "🦡Badger")
-	SetNickname(user, "")
+	SetNickname(user, "🦡Badger", "Set nickname")
+	SetNickname(user, "", "Reset nickname")
 
 -- function ChangeDiscordVoice(user, voiceID)
 -- Returns error code 400 if voice channel ID is incorrect
 -- Usage:
 	ChangeDiscordVoice(user, 123456789123456789)
+	ChangeDiscordVoice(user, 123456789123456789, "Moved "..GetPlayerName(user).." to the admin channel")
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -33,5 +33,6 @@ server_exports {
 	"GetGuildRoleList",
 	"ResetCaches",
 	"CheckEqual",
-	"SetNickname"
+	"SetNickname",
+	"ChangeDiscordVoice"
 } 

--- a/server.lua
+++ b/server.lua
@@ -447,7 +447,7 @@ function GetDiscordNickname(user, guild --[[optional]])
 	return nil;
 end
 
-function SetNickname(user, nickname)
+function SetNickname(user, nickname, reason)
 	local discordId = nil
 	for _, id in ipairs(GetPlayerIdentifiers(user)) do
 		if string.match(id, 'discord:') then
@@ -459,14 +459,14 @@ function SetNickname(user, nickname)
 	if discordId then
 		local name = nickname or ""
 		local endpoint = ("guilds/%s/members/%s"):format(Config.Guild_ID, discordId)
-		local member = DiscordRequest("PATCH", endpoint, json.encode({nick = tostring(name)}), "Reason for the API call")
+		local member = DiscordRequest("PATCH", endpoint, json.encode({nick = tostring(name)}), reason)
 		if member.code ~= 200 then
 			print("[Badger_Perms] ERROR: Code 200 was not reached. Error Code: " .. error_codes_defined[member.code])
 		end
 	end
 end
 
-function ChangeDiscordVoice(user, voice)
+function ChangeDiscordVoice(user, voice, reason)
 	local discordId = nil
 	for _, id in ipairs(GetPlayerIdentifiers(user)) do
 		if string.match(id, "discord:") then
@@ -476,7 +476,7 @@ function ChangeDiscordVoice(user, voice)
 
 	if discordId then
 		local endpoint = ("guilds/%s/members/%s"):format(Config.Guild_ID, discordId)
-		local member = DiscordRequest("PATCH", endpoint, json.encode({channel_id = voice}), "Reason for the API call")
+		local member = DiscordRequest("PATCH", endpoint, json.encode({channel_id = voice}), reason)
 		if member.code ~= 200 then
 			print("[Badger_Perms] ERROR: Code 200 was not reached. Error Code: " .. error_codes_defined[member.code])
 		end


### PR DESCRIPTION
- Added an optional parameter for the functions to specify the reason for the API calls. These will get displayed in the Audit Log on your Discord server.
- Added a voice channel switcher function to let developers move users that are in a voice channel. Returns error code 400 on invalid channel ID provided. With slight modifications, it can be used to mute or deafen users: https://discord.com/developers/docs/resources/guild#modify-guild-member