### PR TITLE
Add 2 new exports: get Guild by role ID and Role name from role ID

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -40,5 +40,7 @@ server_exports {
 	"RemoveRole",
 	"ChangeDiscordVoice",
 	"ClearCache",
-	"FetchRoleID"
+	"FetchRoleID",
+	"FindGuildForRole",
+	"RoleNameFromId"
 } 

--- a/server.lua
+++ b/server.lua
@@ -402,12 +402,16 @@ end
 
 recent_role_cache = {}
 function FindGuildForRole(roleId)
-	local roleFound = false
+	local roleFound
 	local tempGuildList = Config.Guilds
-	tempGuildList["main"] = Config.Guild_ID
+	tempGuildList["main_guild_abcd1010"] = Config.Guild_ID
 
-	if roleGuilds[tostring(roleId)] then
-		return roleGuilds[tostring(roleId)]
+  if not roleId then
+    sendDebugMessage("[Badger_Discord_API] ERROR: Invalid usage of FindGuildForRole. Requires `roleId` arg.")
+  end
+  roleId = tostring(roleId)
+	if roleGuilds[roleId] then
+		return roleGuilds[roleId]
 	end
 
 	for _,id in pairs(tempGuildList) do
@@ -416,8 +420,8 @@ function FindGuildForRole(roleId)
 			local data = json.decode(guild.data)
 			local roles = data.roles;
 			for i = 1, #roles do
-				if tostring(roles[i].id) == tostring(roleId) then
-					roleGuilds[tostring(roleId)] = id
+				if tostring(roles[i].id) == roleId then
+					roleGuilds[roleId] = id
 					roleFound = id
 					break
 				end
@@ -427,7 +431,7 @@ function FindGuildForRole(roleId)
 				break
 			end
 		else
-			print("[Badger_Perms] An error occured, please check your config and ensure everything is correct. Error: "..(guild.data or guild.code)) 
+			sendDebugMessage("[Badger_Discord_API] ERROR: please check your config and ensure everything is correct. Error: "..tostring(guild.code))
 		end
 	end
 

--- a/server.lua
+++ b/server.lua
@@ -440,24 +440,35 @@ end
 
 function RoleNameFromId(id, guild)
 	local guildRoles = false
-	local roleName = 'N/A'
+	local roleName
 
-	if roleNames[tostring(id)] then
-		return roleNames[tostring(id)]
+  if not id then
+    sendDebugMessage("[Badger_Discord_API] ERROR: Invalid usage of RoleNameFromId. Requires `id` arg.")
+    return roleName
+  end
+  id = tostring(id)
+	if roleNames[id] then
+		return roleNames[id]
 	end
-
+  if not guild then guild = FindGuildForRole(id) end
+  if not guild then
+    sendDebugMessage("[Badger_Discord_API] ERROR: RoleNameFromId could not find guild for role ["..id.."]")
+  end
+  guild = tostring(guild)
 	guildRoles = GetGuildRoleList(guild)
 
 	if guildRoles then
 		for k, v in pairs(guildRoles) do
-			if tostring(v) == tostring(id) then
-				roleNames[tostring(id)] = k
+			if tostring(v) == id then
+				roleNames[id] = k
 				roleName = k
 				break
 			end
 		end
 	end
-
+  if not roleName then
+    sendDebugMessage("[Badger_Discord_API] ERROR: Could not find name for role ["..id.."] in guild ["..guild.."]")
+  end
 	return roleName
 end
 


### PR DESCRIPTION
We had a few use cases for these functions come up, so https://github.com/R3site created these, and I applied some modifications so they'd be suitable for general use.

**Usage:**
- `exports['Badger_Discord_API']:FindGuildForRole(roleId)`: returns guild ID of the guild which has the provided role (if one exists).
- `exports['Badger_Discord_API']:RoleNameFromId(roleid,guild)`: returns the role name of given role ID. The guild argument is optional and if not included will use FindGuildForRole to seek that role name.